### PR TITLE
[Automation] Bump product version numbers

### DIFF
--- a/config/versions.yml
+++ b/config/versions.yml
@@ -61,7 +61,7 @@ versioning_systems:
     current: 4.8.0
   apm_agent_rum:
     base: 5.0
-    current: 5.17.0
+    current: "@elastic/apm-rum@5.17.0"
 
   # EDOTs
   edot_collector:

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -52,7 +52,7 @@ versioning_systems:
     current: 4.13.0
   apm_agent_php:
     base: 1.0
-    current: 1.15
+    current: 1.15.1
   apm_agent_python:
     base: 6.0
     current: 6.23.0

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -66,7 +66,7 @@ versioning_systems:
   # EDOTs
   edot_collector:
     base: 9.0
-    current: 9.0.3
+    current: 9.0.4
   edot_ios:
     base: 1.0
     current: 1.2.1

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -58,7 +58,7 @@ versioning_systems:
     current: 6.23.0
   apm_agent_ruby:
     base: 4.0
-    current: 4.7.3
+    current: 4.8.0
   apm_agent_rum:
     base: 5.0
     current: 5.17.0

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -26,7 +26,7 @@ versioning_systems:
     current: 1.15.0
   curator:
     base: 8.0
-    current: 8.21
+    current: 8.0.21
 
   # serverless
   serverless: *all

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -46,7 +46,7 @@ versioning_systems:
     current: 2.7.1
   apm_agent_java:
     base: 1.0
-    current: 1.54.0
+    current: 1.55.0
   apm_agent_node:
     base: 4.0
     current: 4.13.0

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -23,7 +23,7 @@ versioning_systems:
   # things that i don't know about
   ecctl:
     base: 1.0
-    current: 1.15
+    current: 1.15.0
   curator:
     base: 8.0
     current: 8.21

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -16,7 +16,7 @@ versioning_systems:
   ech: *all
   eck:
     base: 3.0
-    current: 3.2
+    current: 3.0.0
   ess: *all
   self: *stack
 

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -43,7 +43,7 @@ versioning_systems:
     current: 1.32.2
   apm_agent_go:
     base: 2.0
-    current: 2.71
+    current: 2.7.1
   apm_agent_java:
     base: 1.0
     current: 1.54.0

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -87,7 +87,7 @@ versioning_systems:
     current: 1.0.0
   edot_python:
     base: 1.0
-    current: 1.3.0
+    current: 1.4.0
   edot_cf_aws:
     base: 0.1
     current: 0.1.6

--- a/config/versions.yml
+++ b/config/versions.yml
@@ -2,7 +2,7 @@ versioning_systems:
   stack: &stack
     base: 9.0
     current: 9.0.4
-  
+
   # Using an unlikely high version
   # So that our logic that would display "planned" doesn't trigger
   all: &all
@@ -27,7 +27,7 @@ versioning_systems:
   curator:
     base: 8.0
     current: 8.21
-  
+
   # serverless
   serverless: *all
   elasticsearch: *all
@@ -36,11 +36,11 @@ versioning_systems:
 
   # APM agents
   # apm_agent_android:
-    # base: 1.0
-    # current: 1.0.0
+  # base: 1.0
+  # current: 1.0.0
   apm_agent_dotnet:
     base: 1.0
-    current: 1.32.0
+    current: 1.32.2
   apm_agent_go:
     base: 2.0
     current: 2.71
@@ -91,4 +91,3 @@ versioning_systems:
   edot_cf_aws:
     base: 0.1
     current: 0.1.6
-  


### PR DESCRIPTION



<Actions>
    <action id="bfbda0570cfbf1ebee5ba4801497a4b00fe1289653863b5c09f26db4b8c67c6e">
        <h3>Bump release versions in the config/versions.yml</h3>
        <details id="00fac1b4e16ca3a7cb1b6cfb0ff393926557a20f4e92426ba098a8c8c7293523">
            <summary>Update config/versions.yml apm_agent_php 1.15.1</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.versioning_systems.apm_agent_php.current&#34; updated from &#34;1.15&#34; to &#34;1.15.1&#34;, in file &#34;config/versions.yml&#34;</p>
            <details>
                <summary>v1.15.1</summary>
                <pre>For more information, please see the [changelog](https://www.elastic.co/guide/en/apm/agent/php/current/release-notes.html).</pre>
            </details>
        </details>
        <details id="07c621c44a6fe5bbdf309a9eb117a8c6745e14b34598d1244aab48251a2d1498">
            <summary>Update config/versions.yml apm_agent_dotnet 1.32.2</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.versioning_systems.apm_agent_dotnet.current&#34; updated from &#34;1.32.0&#34; to &#34;1.32.2&#34;, in file &#34;config/versions.yml&#34;</p>
            <details>
                <summary>v1.32.2</summary>
                <pre>## Bug fixes&#xD;&#xA;- #2602 Fix NullReferenceException in TryToCompressRegular method in Span.</pre>
            </details>
        </details>
        <details id="51e83916f10d790202f65434da54db609f5df431fa79da46f7631fc6e9ef181f">
            <summary>Update config/versions.yml eck 3.0.0</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.versioning_systems.eck.current&#34; updated from &#34;3.2&#34; to &#34;3.0.0&#34;, in file &#34;config/versions.yml&#34;</p>
            <details>
                <summary>v3.0.0</summary>
                <pre># Elastic Cloud on Kubernetes 3.0.0&#xD;&#xA;- [Quickstart guide](https://www.elastic.co/guide/en/cloud-on-k8s/2.16/k8s-quickstart.html)&#xD;&#xA;&#xD;&#xA;### Release Highlights&#xD;&#xA;- ECK 3.0.0 adds support for Elastic Stack version 9.0.0. Elastic Stack version 9.0.0 is not supported on ECK operators running versions earlier than 3.0.0.&#xD;&#xA;&#xD;&#xA;### Features and enhancements&#xD;&#xA;- Add support for defining `dnsPolicy` and `dnsConfig` options for the ECK operator StatefulSet [#7999](https://github.com/elastic/cloud-on-k8s/pull/7999)&#xD;&#xA;- Config: Allow escaping dots in keys via `[unsplit.key]` syntax [#8512](https://github.com/elastic/cloud-on-k8s/pull/8512) (issue: [#8499](https://github.com/elastic/cloud-on-k8s/issues/8499))&#xD;&#xA;- Enable copying of ECK images to Amazon ECR to make it easier for users to find our own ECK operator in the AWS marketplace [#8427](https://github.com/elastic/cloud-on-k8s/pull/8427)&#xD;&#xA;- Support new agent image path as of 9.0 [#8518](https://github.com/elastic/cloud-on-k8s/pull/8518)&#xD;&#xA;- Remove ubi suffix for 9.x images [#8509](https://github.com/elastic/cloud-on-k8s/pull/8509)&#xD;&#xA;- Remove support for 6.x Stack version [#8507](https://github.com/elastic/cloud-on-k8s/pull/8507)&#xD;&#xA;- Log resourceVersion on Create and Update [#8503](https://github.com/elastic/cloud-on-k8s/pull/8503)&#xD;&#xA;- Remove policyID validation [#8449](https://github.com/elastic/cloud-on-k8s/pull/8449) (issue: [#8446](https://github.com/elastic/cloud-on-k8s/issues/8446))&#xD;&#xA;- Refactor APM server for 9.0.0 [#8448](https://github.com/elastic/cloud-on-k8s/pull/8448) (issue: [#8447](https://github.com/elastic/cloud-on-k8s/issues/8447))&#xD;&#xA;- Improve error messages and events during Fleet setup [#8350](https://github.com/elastic/cloud-on-k8s/pull/8350)&#xD;&#xA;- Validate updates to 9.0 go through 8.18 [#8559](https://github.com/elastic/cloud-on-k8s/pull/8559) (issue: [#8557](https://github.com/elastic/cloud-on-k8s/issues/8557))&#xD;&#xA;&#xD;&#xA;### Fixes&#xD;&#xA;- Correctly parse managed namespaces when specified as an environment variable [#8513](https://github.com/elastic/cloud-on-k8s/pull/8513) (issue: [#7542](https://github.com/elastic/cloud-on-k8s/issues/7542))&#xD;&#xA;&#xD;&#xA;### Documentation improvements&#xD;&#xA;- Fix unresolved attribute in ECK Quickstart [#8432](https://github.com/elastic/cloud-on-k8s/pull/8432)&#xD;&#xA;- Add synthetic monitoring example [#8385](https://github.com/elastic/cloud-on-k8s/pull/8385) (issue: [#6294](https://github.com/elastic/cloud-on-k8s/issues/6294))&#xD;&#xA;- Update heap dump command to use the most recent Java process [#8294](https://github.com/elastic/cloud-on-k8s/pull/8294)&#xD;&#xA;- Document the need for an ingest node for Enterprise Search analytics [#8271](https://github.com/elastic/cloud-on-k8s/pull/8271)&#xD;&#xA;&#xD;&#xA;### Miscellaneous&#xD;&#xA;- chore(deps): update Docker tag `registry.access.redhat.com/ubi9/ubi-minimal` to `v9.5-1741850109` [#8544](https://github.com/elastic/cloud-on-k8s/pull/8544)&#xD;&#xA;- Update `golang.org/x/net` package to `0.38.0` [#8591](https://github.com/elastic/cloud-on-k8s/pull/8591)&#xD;&#xA;- chore(deps): update Docker tag `docker.elastic.co/wolfi/go` to `v1.24` [#8453](https://github.com/elastic/cloud-on-k8s/pull/8453)&#xD;&#xA;- fix(deps): update module `go.elastic.co/apm/v2/*` to `v2.6.3` [#8440](https://github.com/elastic/cloud-on-k8s/pull/8440)&#xD;&#xA;- chore(deps): update Wolfi to `v1.23.5-r1` [#8434](https://github.com/elastic/cloud-on-k8s/pull/8434)&#xD;&#xA;- fix(deps): update k8s [#8400](https://github.com/elastic/cloud-on-k8s/pull/8400)&#xD;&#xA;- fix(deps): update module `github.com/gkampitakis/go-snaps` to `v0.5.8` [#8393](https://github.com/elastic/cloud-on-k8s/pull/8393)&#xD;&#xA;- Bump `golang.org/x/crypto` from `0.29.0` to `0.31.0` [#8334](https://github.com/elastic/cloud-on-k8s/pull/8334)&#xD;&#xA;- fix(deps): update module `github.com/prometheus/common` to `v0.61.0` [#8333](https://github.com/elastic/cloud-on-k8s/pull/8333)&#xD;&#xA;- fix(deps): update Kubernetes dependencies to `v0.32.0` and controller-runtime to `v0.19.3` [#8330](https://github.com/elastic/cloud-on-k8s/pull/8330)&#xD;&#xA;- fix(deps): update module `github.com/magiconair/properties` to `v1.8.9` [#8307](https://github.com/elastic/cloud-on-k8s/pull/8307)&#xD;&#xA;- chore(deps): update Docker tag `docker.elastic.co/wolfi/go` to `v1.23.4` [#8306](https://github.com/elastic/cloud-on-k8s/pull/8306)&#xD;&#xA;- fix(deps): update module `github.com/stretchr/testify` to `v1.10.0` [#8282](https://github.com/elastic/cloud-on-k8s/pull/8282)</pre>
            </details>
        </details>
        <details id="614a109c2a9d8554c05e9620e3ffc3a445fa8906f41d29f963fe6c60a1e264e6">
            <summary>Update config/versions.yml edot-python 1.4.0</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.versioning_systems.edot_python.current&#34; updated from &#34;1.3.0&#34; to &#34;1.4.0&#34;, in file &#34;config/versions.yml&#34;</p>
            <details>
                <summary>v1.4.0</summary>
                <pre>## What&#39;s Changed&#xD;&#xA;&#xD;&#xA;- Introduce OpAMP agent for Central configuration. Central configuration will be available in Elastic Stack 9.1 (#320)&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/elastic/elastic-otel-python/compare/v1.3.0...v1.4.0</pre>
            </details>
        </details>
        <details id="766a8e6b099c26a12f73213d1414ed6c34aa8c14ee67c3be1422754d77242873">
            <summary>Update config/versions.yml curator 8.0.21</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.versioning_systems.curator.current&#34; updated from &#34;8.21&#34; to &#34;8.0.21&#34;, in file &#34;config/versions.yml&#34;</p>
            <details>
                <summary>v8.0.21</summary>
                <pre>No, it&#39;s not an April Fool&#39;s joke. This is a real release.&#xD;&#xA;&#xD;&#xA;## Bugfix Release&#xD;&#xA;&#xD;&#xA;As was reported in #1704, the `--ignore_empty_list` option was not being respected.&#xD;&#xA;Code changes were made to each singleton that uses the `--ignore_empty_list` option&#xD;&#xA;to ensure that the option is respected.&#xD;&#xA;&#xD;&#xA;## Changes&#xD;&#xA;&#xD;&#xA;  * Fix `--ignore_empty_list` option to be respected in all singletons.&#xD;&#xA;  * Add debug message to IndexList class when an empty list condition is encountered.&#xD;&#xA;  * Dependency version bump: `es_client` to `8.17.5`</pre>
            </details>
        </details>
        <details id="871abf97a2be8f3694240e667098fee1524cce60c308d189e5bc4a95c607a572">
            <summary>Update config/versions.yml edot-collector 9.0.4</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.versioning_systems.edot_collector.current&#34; updated from &#34;9.0.3&#34; to &#34;9.0.4&#34;, in file &#34;config/versions.yml&#34;</p>
            <details>
                <summary>v9.0.4</summary>
                <pre>Downloads: https://elastic.co/downloads/elastic-agent&#xA;Release notes: https://www.elastic.co/docs/release-notes/fleet#fleet-elastic-agent-9.0.4-release-notes&#xA;</pre>
            </details>
        </details>
        <details id="9a16ec2a3ea3fd84115ddc299a5bbbc4f45758c70b712bc8ea03121cd1e5f4bf">
            <summary>Update config/versions.yml apm_agent_rum @elastic/apm-rum@5.17.0</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.versioning_systems.apm_agent_rum.current&#34; updated from &#34;5.17.0&#34; to &#34;@elastic/apm-rum@5.17.0&#34;, in file &#34;config/versions.yml&#34;</p>
            <details>
                <summary>@elastic/apm-rum@5.17.0</summary>
                <pre>Please check the changelog - https://www.elastic.co/guide/en/apm/agent/rum-js/current/release-notes.html</pre>
            </details>
        </details>
        <details id="aa948bed1ec78f3e36db4e371148feaa45efde51b7e92b1eb8167bc69cb9aa11">
            <summary>Update config/versions.yml apm_agent_java 1.55.0</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.versioning_systems.apm_agent_java.current&#34; updated from &#34;1.54.0&#34; to &#34;1.55.0&#34;, in file &#34;config/versions.yml&#34;</p>
            <details>
                <summary>v1.55.0</summary>
                <pre>[Release Notes for 1.55.0](https://www.elastic.co/docs/release-notes/apm/agents/java#elastic-apm-java-agent-1-55-0-release-notes)&#xA;  ### ARNs of the APM Java Agent AWS Lambda Layer&#xA;&#xA;|Region|ARN|&#xA;|------|---|&#xA;|af-south-1|arn:aws:lambda:af-south-1:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|ap-east-1|arn:aws:lambda:ap-east-1:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|ap-northeast-1|arn:aws:lambda:ap-northeast-1:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|ap-northeast-2|arn:aws:lambda:ap-northeast-2:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|ap-northeast-3|arn:aws:lambda:ap-northeast-3:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|ap-south-1|arn:aws:lambda:ap-south-1:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|ap-southeast-1|arn:aws:lambda:ap-southeast-1:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|ap-southeast-2|arn:aws:lambda:ap-southeast-2:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|ap-southeast-3|arn:aws:lambda:ap-southeast-3:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|ca-central-1|arn:aws:lambda:ca-central-1:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|eu-central-1|arn:aws:lambda:eu-central-1:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|eu-north-1|arn:aws:lambda:eu-north-1:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|eu-south-1|arn:aws:lambda:eu-south-1:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|eu-west-1|arn:aws:lambda:eu-west-1:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|eu-west-2|arn:aws:lambda:eu-west-2:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|eu-west-3|arn:aws:lambda:eu-west-3:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|me-south-1|arn:aws:lambda:me-south-1:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|sa-east-1|arn:aws:lambda:sa-east-1:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|us-east-1|arn:aws:lambda:us-east-1:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|us-east-2|arn:aws:lambda:us-east-2:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|us-west-1|arn:aws:lambda:us-west-1:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;|us-west-2|arn:aws:lambda:us-west-2:267093732750:layer:elastic-apm-java-ver-1-55-0:1|&#xA;</pre>
            </details>
        </details>
        <details id="aff23cc489ad92ff06e6e2f66d1a28a768b8052ce90898367efcdf4c2612aacd">
            <summary>Update config/versions.yml ecctl 1.15.0</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.versioning_systems.ecctl.current&#34; updated from &#34;1.15&#34; to &#34;1.15.0&#34;, in file &#34;config/versions.yml&#34;</p>
            <details>
                <summary>v1.15.0</summary>
                <pre># Changelog&#xD;&#xA;&#xD;&#xA;Download the release binaries:&#xD;&#xA;&#xD;&#xA;&lt;https://download.elastic.co/downloads/ecctl/1.15.0/ecctl_1.15.0_darwin_amd64.tar.gz&gt;&#xD;&#xA;&lt;https://download.elastic.co/downloads/ecctl/1.15.0/ecctl_1.15.0_darwin_arm64.tar.gz&gt;&#xD;&#xA;&lt;https://download.elastic.co/downloads/ecctl/1.15.0/ecctl_1.15.0_linux_32-bit.deb&gt;&#xD;&#xA;&lt;https://download.elastic.co/downloads/ecctl/1.15.0/ecctl_1.15.0_linux_32-bit.rpm&gt;&#xD;&#xA;&lt;https://download.elastic.co/downloads/ecctl/1.15.0/ecctl_1.15.0_linux_386.tar.gz&gt;&#xD;&#xA;&lt;https://download.elastic.co/downloads/ecctl/1.15.0/ecctl_1.15.0_linux_64-bit.deb&gt;&#xD;&#xA;&lt;https://download.elastic.co/downloads/ecctl/1.15.0/ecctl_1.15.0_linux_64-bit.rpm&gt;&#xD;&#xA;&lt;https://download.elastic.co/downloads/ecctl/1.15.0/ecctl_1.15.0_linux_amd64.tar.gz&gt;&#xD;&#xA;&lt;https://download.elastic.co/downloads/ecctl/1.15.0/ecctl_1.15.0_linux_arm64.tar.gz&gt;&#xD;&#xA;&#xD;&#xA;Checksums are at [ecctl_1.15.0_checksums.txt](https://download.elastic.co/downloads/ecctl/1.15.0/ecctl_1.15.0_checksums.txt).&#xD;&#xA;&#xD;&#xA;## Release notes&#xD;&#xA;&#xD;&#xA;&lt;https://www.elastic.co/docs/release-notes/ecctl#ecctl-1.15.0&gt;</pre>
            </details>
        </details>
        <details id="c8bb8749ba976af40812336399f59a433ed8f2a5441311b1a50abcc9fad48f59">
            <summary>Update config/versions.yml apm_agent_ruby 4.8.0</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.versioning_systems.apm_agent_ruby.current&#34; updated from &#34;4.7.3&#34; to &#34;4.8.0&#34;, in file &#34;config/versions.yml&#34;</p>
            <details>
                <summary>v4.8.0</summary>
                <pre>### Features and enhancements&#xD;&#xA;&#xD;&#xA;- Support ruby 3.4 [#1510](https://github.com/elastic/apm-agent-ruby/pull/1510)</pre>
            </details>
        </details>
        <details id="de520628c5708af3a841d87a2e801b886a988be7d41cbd93e99567be2c6f5901">
            <summary>Update config/versions.yml apm_agent_go 2.7.1</summary>
            <p>change detected:&#xA;&#xA;* key &#34;$.versioning_systems.apm_agent_go.current&#34; updated from &#34;2.71&#34; to &#34;2.7.1&#34;, in file &#34;config/versions.yml&#34;</p>
            <details>
                <summary>v2.7.1</summary>
                <pre>## What&#39;s Changed&#xD;&#xA;* [docs] Remove AsciiDoc changelog file by @colleenmcginnis in https://github.com/elastic/apm-agent-go/pull/1700&#xD;&#xA;* Remove fips mention from release notes by @dmathieu in https://github.com/elastic/apm-agent-go/pull/1701&#xD;&#xA;* build(deps): bump docker/login-action from 3.3.0 to 3.4.0 in the github-actions group by @dependabot in https://github.com/elastic/apm-agent-go/pull/1702&#xD;&#xA;* Updates navigation titles for release notes by @KOTungseth in https://github.com/elastic/apm-agent-go/pull/1704&#xD;&#xA;* [docs] Miscellaneous docs clean up by @colleenmcginnis in https://github.com/elastic/apm-agent-go/pull/1705&#xD;&#xA;* fix: revert fips changes by @kruskall in https://github.com/elastic/apm-agent-go/pull/1706&#xD;&#xA;* [docs] Remove reliance on temporary redirects by @colleenmcginnis in https://github.com/elastic/apm-agent-go/pull/1708&#xD;&#xA;* `responseWriter` to implement `Unwrap` method for use by `http.ResponseController` by @lucasmrod in https://github.com/elastic/apm-agent-go/pull/1707&#xD;&#xA;* [docs] Update APM, Synthetics, Uptime links by @colleenmcginnis in https://github.com/elastic/apm-agent-go/pull/1709&#xD;&#xA;* Add patch version to required go version by @dmathieu in https://github.com/elastic/apm-agent-go/pull/1714&#xD;&#xA;* build(deps): bump golang.org/x/crypto from 0.31.0 to 0.35.0 in /module/apmechov4 by @dependabot in https://github.com/elastic/apm-agent-go/pull/1710&#xD;&#xA;* build(deps): bump golang.org/x/net from 0.23.0 to 0.36.0 in /module/apmgoredisv8 by @dependabot in https://github.com/elastic/apm-agent-go/pull/1696&#xD;&#xA;* build(deps): bump golang.org/x/crypto from 0.31.0 to 0.35.0 in /module/apmsql by @dependabot in https://github.com/elastic/apm-agent-go/pull/1715&#xD;&#xA;* build(deps): bump golang.org/x/crypto from 0.31.0 to 0.35.0 in /module/apmgin by @dependabot in https://github.com/elastic/apm-agent-go/pull/1716&#xD;&#xA;* build(deps): bump golang.org/x/crypto from 0.31.0 to 0.35.0 in /module/apmmongo by @dependabot in https://github.com/elastic/apm-agent-go/pull/1717&#xD;&#xA;* build(deps): bump golang.org/x/crypto from 0.31.0 to 0.35.0 in /module/apmecho by @dependabot in https://github.com/elastic/apm-agent-go/pull/1718&#xD;&#xA;* github-action: add supported GitHub commands by @v1v in https://github.com/elastic/apm-agent-go/pull/1721&#xD;&#xA;* build(deps): bump golang.org/x/net from 0.23.0 to 0.38.0 in /module/apmechov4 by @dependabot in https://github.com/elastic/apm-agent-go/pull/1723&#xD;&#xA;* build(deps): bump golang.org/x/net from 0.23.0 to 0.38.0 in /module/apmgoredis by @dependabot in https://github.com/elastic/apm-agent-go/pull/1722&#xD;&#xA;* [docs] Add `products` to `docset.yml` by @colleenmcginnis in https://github.com/elastic/apm-agent-go/pull/1725&#xD;&#xA;* fix: prevent marshaling invalid floats by @kruskall in https://github.com/elastic/apm-agent-go/pull/1720&#xD;&#xA;* build(deps): bump golang.org/x/net from 0.33.0 to 0.38.0 in /module/apmgokit by @dependabot in https://github.com/elastic/apm-agent-go/pull/1728&#xD;&#xA;* build(deps): bump golang.org/x/net from 0.33.0 to 0.38.0 in /internal/apmgodog by @dependabot in https://github.com/elastic/apm-agent-go/pull/1727&#xD;&#xA;* feat: release v2.7.1 by @kruskall in https://github.com/elastic/apm-agent-go/pull/1730&#xD;&#xA;&#xD;&#xA;## New Contributors&#xD;&#xA;* @KOTungseth made their first contribution in https://github.com/elastic/apm-agent-go/pull/1704&#xD;&#xA;* @lucasmrod made their first contribution in https://github.com/elastic/apm-agent-go/pull/1707&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/elastic/apm-agent-go/compare/v2.7.0...v2.7.1</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

